### PR TITLE
Fixing #13 '...rror: (404) Error fetching the URL'

### DIFF
--- a/gfycat/constants.py
+++ b/gfycat/constants.py
@@ -20,6 +20,7 @@ CONTENT_TYPE = 'image/gif'
 
 # Query
 QUERY_ENDPOINT = 'https://api.gfycat.com/v1/gfycats/'
+QUERY_FALLBACK = 'https://api.redgifs.com/v1/gfycats/'
 
 # Check Link
 CHECK_LINK_ENDPOINT = 'https://gfycat.com/cajax/checkUrl/'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.2.2',
+    version='0.2.3',
 
     description='A Python client for the Gfycat API',
     long_description='',


### PR DESCRIPTION
Some content has been split-off to redgif which observes the same API
So a simple recursive fallback is added that checks the secondary site
before failing.